### PR TITLE
Fix license link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ License
 
 If you'd try to sell it on Asset Store, then I'm gonna find you.
 
-See [LICENSE.md](LICENSE.md) for details.
+See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Hello! I don't actually use Unity 3D but I follow /r/unity3d anyway and found your post. Cool asset, but I noticed the LICENSE link in your README was incorrect.

You could make this change yourself instead of accepting, if you'd rather I didn't show up as a "[contributor](https://github.com/PavelDoGreat/Super-Blur/graphs/contributors)" for such a minor change.

Thanks for sharing your asset with the MIT license!